### PR TITLE
Json Report Generation Option is added for DevSecOps CI/CD pipeline

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6,9 +6,15 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("-d", "--directory", nargs='+',
                         help="Path to Node.js Source Code to Scan", required=True)
+    parser.add_argument("-r","--results",
+                        help="Generate Json report for DevSecOps CI/CD pipelines", required=False )
     args = parser.parse_args()
-    if args.directory:
+    if args.directory and not args.results:
         scan_results = general_code_analysis(args.directory)
         print (json.dumps(scan_results))
+    elif args.directory and args.results:
+    	scan_results = general_code_analysis(args.directory)
+    	with open(str(args.results)+".json", 'w') as outfile:
+			json.dump(scan_results, outfile,sort_keys=True, indent=4, separators=(',', ': '))
     else:
         parser.print_help()


### PR DESCRIPTION
@ajinabraham Currently NodeJsScan does not support Json file generation option in ``NodeJsScan Cli``. Could you please  check and merge this PR, so it will be helpful for all user to generate Json file in CI/CD Pipeline.