### PR TITLE
Added CLI Docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ Static security code scanner (SAST) for Node.js applications.
 [![python](https://img.shields.io/badge/python-3.6-blue.svg)](https://www.python.org/downloads/)
 [![Requirements Status](https://requires.io/github/ajinabraham/NodeJsScan/requirements.svg?branch=master)](https://requires.io/github/ajinabraham/NodeJsScan/requirements/?branch=master)
 
-### Configure & Run NodeJsScan
+## Configure & Run NodeJsScan
 
 Install Postgres and configure `SQLALCHEMY_DATABASE_URI` in `core/settings.py`
 
-```
+```bash
 pip3 install -r requirements.txt
 python3 migrate.py # Run once to create database entries required
 python3 app.py # Testing Environment
@@ -22,11 +22,11 @@ This will run NodeJsScan on `http://0.0.0.0:9090`
 
 If you need to debug, set `DEBUG = True` in `core/settings.py`
 
-### NodeJsScan CLI
+## NodeJsScan CLI
 
 The command line interface (CLI) allows you to integrate NodeJsScan with DevSecOps CI/CD pipelines. The results are in JSON format. When you use CLI the results are never stored with NodeJsScan backend.
 
-```
+```bash
 virtualenv venv -p python3
 source venv/bin/activate
 (venv)pip install nodejsscan
@@ -45,9 +45,9 @@ optional arguments:
   -v, --version         Show nodejsscan version
 ```
 
-#### Python API
+## Python API
 
-```
+```python
 import core.scanner as njsscan
 res_dir = njsscan.scan_dirs(['/Code/Node.Js-Security-Course'])
 res_file = njsscan.scan_file(['/Code/Node.Js-Security-Course/deserialization.js'])
@@ -57,30 +57,43 @@ print(res_file)
 
 ```
 
-### Docker
+## Docker
 
-```
-docker build -t nodejsscan .
-docker run -it -p 9090:9090 nodejsscan
-```
+NodeJsScan Docker images can be built for both the Web UI and CLI version.
 
-### DockerHub
+* Web UI
 
-```
+  ```bash
+  docker build -t nodejsscan .
+  docker run -it -p 9090:9090 nodejsscan
+  ```
+
+* CLI
+
+  ```bash
+  # Use -f to override default Dockerfile
+  docker build -t nodejsscan-cli -f cli.dockerfile  .
+  # Mount a volume to the container that points to your source directory and reference it in -f, -d and -o arguments
+  docker run -v /path-to-source-dir:/src nodejsscan-cli -d /src -o /src/results.json
+  ```
+
+## DockerHub
+
+```bash
 docker pull opensecurity/nodejsscan
 docker run -it -p 9090:9090 opensecurity/nodejsscan:latest
 ```
 
-### Learn Node.js Security: Pentesting and Exploitation
+## Learn Node.js Security: Pentesting and Exploitation
 
 [![OpSecX Video Course](https://user-images.githubusercontent.com/4301109/43572791-f54e87f6-965d-11e8-8811-7a8900df3379.png)](https://opsecx.com/index.php/product/node-js-security-pentesting-and-exploitation/?uid=github)
 
+## NodeJsScan Web UI
 
-#### NodeJsScan Web UI
 ![NodeJsScan](https://cloud.githubusercontent.com/assets/4301109/22619224/26acd162-eb16-11e6-8f28-bd477c92991f.png)
 
-#### Static Analysis
+## Static Analysis
+
 ![NodeJsScan Static Scan Results](https://user-images.githubusercontent.com/4301109/33951861-294062a0-e056-11e7-8472-3c101be52390.jpg)
 ![NodeJsScan Static Scan Vulnerability Details](https://user-images.githubusercontent.com/4301109/30637698-bfa68e04-9e16-11e7-8233-bfde503d7e5a.png)
 ![NodeJsScan CLI](https://user-images.githubusercontent.com/4301109/43541417-0a749362-95e8-11e8-9d5c-4d9a2fd9f765.png)
-

--- a/cli.dockerfile
+++ b/cli.dockerfile
@@ -1,0 +1,14 @@
+FROM python:3-alpine
+
+WORKDIR /usr/src/app
+
+# Copy required files from host to image
+COPY ./cli.requirements.txt ./
+COPY ./core ./core
+
+# Install required dependencies
+RUN pip install --no-cache-dir -r cli.requirements.txt \
+    # Move cli.py from /usr/src/app/core to /usr/src/app
+    && mv ./core/cli.py .
+
+ENTRYPOINT ["python","cli.py"]

--- a/cli.requirements.txt
+++ b/cli.requirements.txt
@@ -1,0 +1,4 @@
+flask==1.0.2
+jinja2==2.10
+defusedxml==0.5.0
+jsbeautifier==1.9.0

--- a/core/cli.py
+++ b/core/cli.py
@@ -12,7 +12,8 @@ import core.settings as settings
 def output(out, scan_results):
     """Output"""
     if out:
-        with open("./" + out + ".json", 'w') as outfile:
+        # out is the fully qualified path and filename for the ouptput file. We recommend you use a .json extension
+        with open(out, 'w') as outfile:
             json.dump(scan_results, outfile, sort_keys=True,
                       indent=4, separators=(',', ': '))
     else:


### PR DESCRIPTION
I really appreciate the GUI Docker image but wanted to integrate the NodeJsScan CLI into my build pipeline using Docker. 

I created two new files, cli.dockerfile and cli.requirements.txt but had to modify line 15 in cli.py so that it would accept a full path instead of just a filename. This is necessary so that the outfile can be written to the mounted volume. I also updated README.md with the CLI image instructions. 