### PR TITLE
Changed Dockerfile startups to use absolute path for working directory independence

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,4 @@ RUN cd /usr/src \
 
 ADD start.sh /usr/src/NodeJsScan
 WORKDIR /usr/src/NodeJsScan
-CMD ["sh","start.sh"]
+CMD ["sh","/usr/src/NodeJsScan/start.sh"]

--- a/cli.dockerfile
+++ b/cli.dockerfile
@@ -11,4 +11,4 @@ RUN pip install --no-cache-dir -r cli.requirements.txt \
     # Move cli.py from /usr/src/app/core to /usr/src/app
     && mv ./core/cli.py .
 
-ENTRYPOINT ["python","cli.py"]
+ENTRYPOINT ["python","/usr/src/app/cli.py"]


### PR DESCRIPTION
Changed Docker image startups to use absolute path so that the image is not dependent on working directory for execution.

While unlikely, a user might set their working directory as part of their volume mount or other reason. This change allows the image to continue to work
without requiring the user to change how their images are run.

Another approach would be to let it happen and explain to a user why they need to change their command, but it might be easier to have it "just work"(tm).