### PR TITLE
Dockerfile updates/efficiencies to reproduce builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,94 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# IPython Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject
+#Mac
+.DS_Store
+*.pyc
+*.pyo
+njs-log.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,21 @@
 FROM postgres:9.6.2-alpine
-
 LABEL authors="Cristobal Infantes <cristobal.infantes@gmail.com>" \
-	  maintainer="Ajin Abraham <ajin25@gmail.com>" \
-	  description="Static Security Code Scanner for Node.js Applications"
-
+   maintainer="Ajin Abraham <ajin25@gmail.com>" \
+   description="Static Security Code Scanner for Node.js Applications"
 EXPOSE 9090
-
 ENV POSTGRES_USER root
 ENV POSTGRES_DB nodejsscan
-
-RUN cd /usr/src \
- && apk add --update \
-    python3 \
-    python3-dev \
-    build-base \
-    git \
- && python3 -m ensurepip \
- && git clone https://github.com/ajinabraham/NodeJsScan.git \
- && cd NodeJsScan \
- && sed -i -e s/postgresql:\\/\\/localhost\\/nodejsscan/postgresql:\\/\\/127.0.0.1\\/nodejsscan/g core/settings.py \
- && pip3 install -r requirements.txt \
- && apk del python3-dev \
-    build-base \
-    git \
- && rm -rf /var/cache/apk/*
-
-ADD start.sh /usr/src/NodeJsScan
+RUN apk add --no-cache \
+   python3=3.5.6-r0 \
+   python3-dev=3.5.6-r0 \
+   build-base=0.4-r1 \
+   && python3 -m ensurepip
 WORKDIR /usr/src/NodeJsScan
+COPY requirements.txt requirements.txt
+WORKDIR /usr/src/NodeJsScan/core
+COPY ./core/settings.py settings.py
+WORKDIR /usr/src/NodeJsScan
+RUN sed -i -e s/postgresql:\\/\\/localhost\\/nodejsscan/postgresql:\\/\\/127.0.0.1\\/nodejsscan/g core/settings.py \
+   && pip3 install -r requirements.txt
+COPY . .
 CMD ["sh","/usr/src/NodeJsScan/start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,17 +5,16 @@ LABEL authors="Cristobal Infantes <cristobal.infantes@gmail.com>" \
 EXPOSE 9090
 ENV POSTGRES_USER root
 ENV POSTGRES_DB nodejsscan
+WORKDIR /usr/src/NodeJsScan
+COPY requirements.txt requirements.txt
+COPY ./core/settings.py ./core/settings.py
 RUN apk add --no-cache \
    python3=3.5.6-r0 \
    python3-dev=3.5.6-r0 \
    build-base=0.4-r1 \
-   && python3 -m ensurepip
-WORKDIR /usr/src/NodeJsScan
-COPY requirements.txt requirements.txt
-WORKDIR /usr/src/NodeJsScan/core
-COPY ./core/settings.py settings.py
-WORKDIR /usr/src/NodeJsScan
-RUN sed -i -e s/postgresql:\\/\\/localhost\\/nodejsscan/postgresql:\\/\\/127.0.0.1\\/nodejsscan/g core/settings.py \
-   && pip3 install -r requirements.txt
+   && python3 -m ensurepip \
+   && sed -i -e s/postgresql:\\/\\/localhost\\/nodejsscan/postgresql:\\/\\/127.0.0.1\\/nodejsscan/g core/settings.py \
+   && pip3 install -r requirements.txt \
+   && apk del python3-dev build-base
 COPY . .
-CMD ["sh","/usr/src/NodeJsScan/start.sh"]
+CMD ["sh","start.sh"]


### PR DESCRIPTION
I've made some suggested changes to the main Dockerfile that will make Docker image builds that are consistent and reproduce-able. A summary of the changes:

- remove the git clone command and copy from the local source. This will allow for users with a local repo or branch to use this Dockerfile to build their own images locally.
- pinned apk package dependency versions. This will require a manual update but future versions won't be accidentally broken automatically.
- added .dockerignore file (copied exactly from from .gitignore)
- optimized order of Dockerfile steps. Dependency layers will be cached and saved for quick building unless `core/settings.py` change or `requirements.txt` change.

This provides a good foundation to use a single Dockerfile for [mutli-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/) (17.05+) (i.e. combining CLI and GUI into a single Dockerfile). This will also provide a good foundation to implement docker image tagging (besides latest) if it is a desired feature in the future (i.e. `opensecurity/nodejsscan:1.0.0` or `opensecurity/nodejsscan:gui` or  `opensecurity/nodejsscan:cli`)