### PR TITLE
rules for koa-helmet & session; validate JS with `import ... from`

### DIFF
--- a/core/rules.xml
+++ b/core/rules.xml
@@ -199,47 +199,47 @@
     <!---if express is used express.limit\(('|")-->
     <!--end if-->
     <missing_header name="Missing Security Header - Content-Security-Policy (CSP)">
-        <signature>require\(('|")helmet-csp('|")\)|helmet.csp|lusca.csp\(|Content-Security-Policy</signature>
+        <signature>\.use\((csp\(|helmet\.contentSecurityPolicy|helmet\({.*contentSecurityPolicy)|lusca.csp\(|Content-Security-Policy|contentSecurityPolicy</signature>
         <description>Content Security Policy (CSP), a mechanism web applications can use to mitigate a broad class of content injection vulnerabilities, such as cross-site scripting (XSS). CSP Header was not found.</description>
         <tag>web</tag>
     </missing_header>
     <missing_header name="Missing Security Header - X-Frame-Options (XFO)">
-        <signature>helmet.xframe|lusca.xframe\(|require\(('|")frameguard('|")\)|frameguard\(|X-Frame-Options</signature>
+        <signature>\.use\((helmet\.frameguard|helmet\(+(.*)frameguard)|lusca.xframe\(|require\((\'|\")frameguard(\'|\")\)|frameguard\(|X-Frame-Options</signature>
         <description>X-Frame-Options (XFO) header provides protection against Clickjacking attacks.</description>
         <tag>web</tag>
     </missing_header>
     <missing_header name="Missing Security Header - Strict-Transport-Security (HSTS)">
-        <signature>helmet.hsts\({|lusca.hsts\({|hsts\({|require\(('|")hsts('|")\)|Strict-Transport-Security</signature>
+        <signature>\.use\((helmet\.hsts|helmet\(+(.*)hsts)|lusca.hsts\({|hsts\({|require\(('|")hsts('|")\)|Strict-Transport-Security</signature>
         <description>Strict-Transport-Security (HSTS) header enforces secure (HTTP over SSL/TLS) connections to the server.</description>
         <tag>web</tag>
     </missing_header>
     <missing_header name="Missing Security Header - Public-Key-Pins (HPKP)">
-        <signature>Public-Key-Pins(:|,)*</signature>
+        <signature>\.use\((helmet\.hpkp|helmet\(+(.*)hpkp)|Public-Key-Pins(:|,)*</signature>
         <description>Public-Key-Pins (HPKP) ensures that certificate is Pinned.</description>
         <tag>web</tag>
     </missing_header>
     <missing_header name="Missing Security Header - X-XSS-Protection:1">
-        <signature>helmet.xssFilter\(\)|lusca.xssProtection\(true\)|X-XSS-Protection('|")*(\s)*(:|,)(\s)*('|")*1</signature>
+        <signature>\.use\((helmet\.xssFilter|helmet\(+(.*)xssFilter)|lusca.xssProtection\(true\)|X-XSS-Protection('|")*(\s)*(:|,)(\s)*('|")*1</signature>
         <description>X-XSS-Protection header set to 1 enables the Cross-site scripting (XSS) filter built into most recent web browsers.</description>
         <tag>web</tag>
     </missing_header>
     <missing_header name="Missing Security Header - X-Content-Type-Options">
-        <signature>helmet.noSniff|require\(('|")dont-sniff-mimetype('|")\)|nosniff\(\)|X-Content-Type-Options('|")*(\s)*(:|,)(\s)*('|")*nosniff</signature>
+        <signature>\.use\((helmet\.noSniff|helmet\(+(.*)noSniff)|require\(('|")dont-sniff-mimetype('|")\)|nosniff\(\)|X-Content-Type-Options('|")*(\s)*(:|,)(\s)*('|")*nosniff</signature>
         <description>X-Content-Type-Options header prevents Internet Explorer and Google Chrome from MIME-sniffing a response away from the declared content-type.</description>
         <tag>web</tag>
     </missing_header>
     <missing_header name="Missing Security Header - X-Download-Options: noopen">
-        <signature>require\(('|")ienoopen('|")\)|ienoopen\(|helmet.ienoopen\(|X-Download-Options('|")*(\s)*(:|,)(\s)*('|")*noopen</signature>
+        <signature>\.use\((helmet\.ieNoOpen|helmet\(+(.*)ieNoOpen)|require\(('|")ienoopen('|")\)|ienoopen\(|X-Download-Options('|")*(\s)*(:|,)(\s)*('|")*noopen</signature>
         <description>X-Download-Options header set to noopen prevents IE users from directly opening and executing downloads in your site's context.</description>
         <tag>web</tag>
     </missing_header>
     <missing_header name="Missing 'httpOnly' in Cookie">
-        <signature>httpOnly(\s)*:(\s)*true|httpOnly</signature>
+        <signature>httpOnly(\s)*:(\s)*true|httpOnly|\.use\(session\(</signature>
         <description>JavaScript can access Cookies if they are not marked httpOnly.</description>
         <tag>web</tag>
     </missing_header>
     <missing_header name="Information Disclosure - X-Powered-By">
-        <signature>.disable\(('|")x-powered-by('|")\)|require\(('|")hide-powered-by('|")\)|hidePoweredBy\(|helmet.hidePoweredBy\(|removeHeader\(('|")X-Powered-By('|")\)|.remove\(('|")X-Powered-By('|")\)</signature>
+        <signature>\.use\((helmet\.hidePoweredBy|helmet\(+(.*)hidePoweredBy)|.disable\(('|")x-powered-by('|")\)|require\(('|")hide-powered-by('|")\)|hidePoweredBy\(|removeHeader\(('|")X-Powered-By('|")\)|.remove\(('|")X-Powered-By('|")\)</signature>
         <description>Remove the X-Powered-By header to prevent information gathering.</description>
         <tag>web</tag>
     </missing_header>

--- a/core/scanner.py
+++ b/core/scanner.py
@@ -17,7 +17,7 @@ import core.settings as settings
 defusedxml.defuse_stdlib()
 MULTI_COMMENT = re.compile(r'/\*[\s\S]+?\*/')
 NODE_RGX = re.compile(
-    r"require\(('|\")(.+?)('|\")\)|module\.exports {0,5}= {0,5}")
+    r"require\(('|\")(.+?)('|\")\)|module\.exports {0,5}= {0,5}|import [ {}\w]+ from ('|\")(.+?)('|\")")
 
 
 def read_rules():
@@ -397,9 +397,11 @@ def code_analysis(data, full_file_path, scan_rules, header_found):
                 addg = add_findings(
                     good_find, scan_rules, line_no, org_lines, full_file_path)
                 good_finding.append(addg)
-        # Missing Security Headers String Match
-        for header in scan_rules["missing_sec_header"].keys():
-            if re.search(scan_rules["missing_sec_header"][header], line, re.I):
-                # Good Header is present
-                header_found[header] = 1
+
+    # Missing Security Headers String Match
+    for header in scan_rules["missing_sec_header"].keys():
+        if re.search(scan_rules["missing_sec_header"][header], san_data, re.I | re.S):
+            # Good Header is present
+            header_found[header] = 1
+
     return security_issues, good_finding


### PR DESCRIPTION
As per #116 , signature for HTTP headers via `koa-helmet`. 
The only exception is that 'httpOnly' in Cookie is set via `koa-session` (https://github.com/koajs/session).  It can be set with default/null config, hence `app.use(session(app))` shall be recognized.

Another changes: 

- not sure why the search was done line by line, searching for the headers via regex on the whole file is more than fine (moreover, it's required via multiline configurations; see the linked issue for an example) - `core/scanner.py` lines 400-406

- JS with `import .. from ..` shall be recognized as valid file - `core/scanner.py` line 20