### PR TITLE
Add docs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include core/rules.xml
+include LICENSE README.md


### PR DESCRIPTION
Add docs to MANIFEST.in. This allows to ship both files with the source tarball that is uploaded to PyPI.

The license file is needed for the Fedora package which is on the way.