### PR TITLE
Add docstring

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core part of nodejsscan."""


### PR DESCRIPTION
The RPM package doesn't like empty file. Ok, it's the linting.

Fixed by adding a docstring acc. PEP257.